### PR TITLE
Updating to allow for HTTPS file detection

### DIFF
--- a/src/cucxabeng/simple-html-dom/HtmlDom.php
+++ b/src/cucxabeng/simple-html-dom/HtmlDom.php
@@ -113,7 +113,7 @@ class HtmlDom{
     {
         if ($str)
         {
-            if (preg_match("/^http:\/\//i",$str) || is_file($str))
+            if (preg_match("/^http:\/\//i",$str) || preg_match("/^https:\/\//i",$str) || is_file($str))
             {
                 $this->load_file($str);
             }


### PR DESCRIPTION
Current configuration only allows for detection of HTTP files. I am sure there is a more concise way to handle this detection with regex, but adding a secondary preg_match conditional for HTTPS works great.